### PR TITLE
Exception check to avoid attribute errors

### DIFF
--- a/robotiq_modbus_rtu/src/robotiq_modbus_rtu/comModbusRtu.py
+++ b/robotiq_modbus_rtu/src/robotiq_modbus_rtu/comModbusRtu.py
@@ -89,6 +89,9 @@ class communication:
       if response is None or isinstance(response, WriteMultipleRegistersResponse):
          raise ModbusIOException('No response from client')
 
+      if isinstance(response, ModbusIOException):
+         raise response
+
       #Instantiate output as an empty list
       output = []
 


### PR DESCRIPTION
pymodbus sometimes returns (and not raise) an exception and that behavior is not properly handled downstream.
Added a check in `comModbusRtu.communication.getStatus` to avoid attribute errors when pymodbus returns an exception. Now the returned exception is raised again.